### PR TITLE
add a module API "shouldSkipUid" to let module decides whether it wanna skip hooking for specified uid or not

### DIFF
--- a/riru-core/jni/main/init.cpp
+++ b/riru-core/jni/main/init.cpp
@@ -80,6 +80,7 @@ static void load_modules() {
             module->forkAndSpecializePost = dlsym(handle, "nativeForkAndSpecializePost");
             module->forkSystemServerPre = dlsym(handle, "nativeForkSystemServerPre");
             module->forkSystemServerPost = dlsym(handle, "nativeForkSystemServerPost");
+            module->shouldSkipUid = dlsym(handle, "shouldSkipUid");
 
             get_modules()->push_back(module);
 

--- a/riru-core/jni/main/jni_native_method.cpp
+++ b/riru-core/jni/main/jni_native_method.cpp
@@ -53,12 +53,15 @@ static void nativeForkAndSpecialize_pre(
         jstring instructionSet, jstring appDataDir) {
     nativeForkAndSpecialize_calls_count++;
 
-    if (shouldSkipUid(uid))
-        return;
-
     for (auto module : *get_modules()) {
         if (!module->forkAndSpecializePre)
             continue;
+
+        if (!module->shouldSkipUid && shouldSkipUid(uid)) {
+            continue;
+        } else if (((shouldSkipUid_t) module->shouldSkipUid)(uid)) {
+            continue;
+        }
 
         //LOGV("%s: forkAndSpecializePre", module->name);
         ((nativeForkAndSpecialize_pre_t) module->forkAndSpecializePre)(
@@ -68,13 +71,16 @@ static void nativeForkAndSpecialize_pre(
 }
 
 static void nativeForkAndSpecialize_post(JNIEnv *env, jclass clazz, jint uid, jint res) {
-    if (shouldSkipUid(uid))
-        return;
 
     for (auto module : *get_modules()) {
         if (!module->forkAndSpecializePost)
             continue;
 
+        if (!module->shouldSkipUid && shouldSkipUid(uid)) {
+            continue;
+        } else if (((shouldSkipUid_t) module->shouldSkipUid)(uid)) {
+            continue;
+        }
         /*
          * Magic problem:
          * There is very low change that zygote process stop working and some processes forked from zygote

--- a/riru-core/jni/main/module.h
+++ b/riru-core/jni/main/module.h
@@ -22,6 +22,8 @@ typedef void (*nativeForkSystemServer_pre_t)(JNIEnv *, jclass, uid_t, gid_t, jin
 
 typedef int (*nativeForkSystemServer_post_t)(JNIEnv *, jclass, jint);
 
+typedef int (*shouldSkipUid_t)(int);
+
 struct module {
     void *handle{};
     char *name;
@@ -30,6 +32,7 @@ struct module {
     void *forkAndSpecializePost{};
     void *forkSystemServerPre{};
     void *forkSystemServerPost{};
+    void *shouldSkipUid{};
     std::map<std::string, void *> * funcs;
 
     explicit module(char *name) : name(name) {


### PR DESCRIPTION
大佬你好，我是 Riru 模块 [EdXposed](https://github.com/ElderDrivers/EdXposed) 的作者，由于我的模块需要能 hook 所有的进程，所以增加了一个模块方法 `shouldSkipUid` 让 Riru 模块自己来决定自己是否需要 hook 指定 uid 的进程。
如果 Riru 模块提供了 `shouldSkipUid` 方法，则用该方法进行判断，否则走 riru-core 里的默认过滤逻辑。
我修改后测试了几部手机，暂时没有遇到zygote无法启动的情况。