### PR TITLE
Fix the rename directory system_x86. Works also for x86_64.

### DIFF
--- a/template/magisk_module/customize.sh
+++ b/template/magisk_module/customize.sh
@@ -36,7 +36,7 @@ extract "$ZIPFILE" 'uninstall.sh' "$MODPATH"
 if [ "$ARCH" = "x86" ] || [ "$ARCH" = "x64" ]; then
   ui_print "- Extracting x86 libraries"
   extract "$ZIPFILE" 'system_x86/lib/libmemtrack.so' "$MODPATH"
-  mv "$MODPATH/system_x86/lib" "$MODPATH/system/lib"
+  mv "$MODPATH/system_x86/" "$MODPATH/system/"
 
   if [ "$IS64BIT" = true ]; then
     ui_print "- Extracting x64 libraries"


### PR DESCRIPTION
When zip is extracted system directory doesn't exist, mv rename only the last child and not all directories so system_86 is not rename to system, so mv fails and riru core is not loaded on android x86. I tested this patch on Android x86 and x86_64 both works.
