### PR TITLE
Fix Riru app install failed

### DIFF
--- a/template/magisk_module/customize.sh
+++ b/template/magisk_module/customize.sh
@@ -127,7 +127,7 @@ if [ -f "/data/adb/modules/riru-core/allow_install_app" ]; then
   ui_print "- Installing app"
   extract "$ZIPFILE" "app.apk" "/data/local/tmp"
   set_perm "/data/local/tmp/app.apk" 2000 1000 0660
-  su 1000 -c '/system/bin/pm install -r /data/local/tmp/app.apk'
+  su -c '/system/bin/pm install -r /data/local/tmp/app.apk'
   rm /data/local/tmp/app.apk
 else
   ui_print "- Skip install app"


### PR DESCRIPTION
UID 1000 does not have enough privileges on some systems. 
e.g. MIUI